### PR TITLE
Update repo links

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://bcrikko.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width:100%;" width="600" height="315"></a>
+  <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width:100%;" width="600" height="315"></a>
 
   <a href="README.md">English</a> / <a href="README-jp.md">日本語</a>
 </div>
@@ -47,7 +47,7 @@ NES.cssはコンポーネントのスタイルのみを提供しています。�
       html, body, pre, code, kbd, samp {
           font-family: "font-family you want to use";
       }
-    </style>    
+    </style>
 </head>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <a href="https://bcrikko.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width:100%;" width="600" height="315"></a>
+  <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width:100%;" width="600" height="315"></a>
 
   <a href="README.md">English</a> / <a href="README-jp.md">日本語</a>
 </div>
@@ -46,7 +46,7 @@ The default font is [Press Start 2P](https://fonts.google.com/specimen/Press+Sta
       html, body, pre, code, kbd, samp {
           font-family: "font-family you want to use";
       }
-    </style>    
+    </style>
 </head>
 ```
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/BcRikko/NES.css.git"
+    "url": "https://github.com/nostalgic-css/NES.css.git"
   },
   "keywords": [
     "css",
@@ -33,9 +33,9 @@
   "author": "BcRikko (https://github.com/Bcrikko)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/BcRikko/NES.css/issues"
+    "url": "https://github.com/nostalgic-css/NES.css/issues"
   },
-  "homepage": "https://github.com/BcRikko/NES.css#readme",
+  "homepage": "https://github.com/nostalgic-css/NES.css#readme",
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",
     "@commitlint/config-conventional": "^7.1.2",


### PR DESCRIPTION
This PR updates the repo links. I updated it in the READMEs to point to the new org version of the repo, and updated the repo link in the `package.json` so that `semantic-release` will work correctly in CI.