### PR TITLE
npm-scripts: fix typo on storybook build name

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "NES.css is NES-style CSS Framework.",
   "scripts": {
     "watch": "npm run build:sass -- --watch",
-    "build": "npm run build:clean && npm run build:stylelint && npm run build:sass && npm run build:autoprefix && npm run build:cleancss && npm run build-storybook",
+    "build": "npm run build:clean && npm run build:stylelint && npm run build:sass && npm run build:autoprefix && npm run build:cleancss && npm run build:storybook",
     "stylelint": "stylelint scss/**/*.scss",
     "build:stylelint": "npm run stylelint -- --fix",
     "build:clean": "rimraf css",


### PR DESCRIPTION
<!-- 
  I'm not very good at English. So, I'm glad if you write in English as easy as possible.
  日本語がわかる方はなるべく日本語でお願いします。
-->
This fixes: https://github.com/nostalgic-css/NES.css/issues/91