### PR TITLE
fix: preserve outline0 for checkboxes and radios only

### DIFF
--- a/scss/base/generic.scss
+++ b/scss/base/generic.scss
@@ -37,6 +37,7 @@ button,
 }
 
 // Prevent stray pixels on focused inputs such as checkboxes and radios
-input {
+input[type="radio"],
+input[type="checkbox"] {
   outline: 0;
 }


### PR DESCRIPTION
Closes #39 

Fixes https://github.com/nostalgic-css/NES.css/pull/44#issuecomment-445416611

|current|this PR|
|----|----|
|![pr](https://user-images.githubusercontent.com/5305599/49679806-730ada00-fad1-11e8-95c7-5dcff4abae57.gif)|![expect](https://user-images.githubusercontent.com/5305599/49679808-74d49d80-fad1-11e8-89f4-9f021f94157f.gif)|
