### PR TITLE
fix script spelling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "NES.css is NES-style CSS Framework.",
   "scripts": {
     "watch": "npm run build:sass -- --watch",
-    "build": "npm run build:clean && npm run build:stylelint && npm run build:sass && npm run build:autoprefix && npm run build:cleancss && npm run build-storybook",
+    "build": "npm run build:clean && npm run build:stylelint && npm run build:sass && npm run build:autoprefix && npm run build:cleancss && npm run build:storybook",
     "stylelint": "stylelint scss/**/*.scss",
     "build:stylelint": "npm run stylelint -- --fix",
     "build:clean": "rimraf css",


### PR DESCRIPTION
```
npm ERR! missing script: build-storybook
npm ERR! 
npm ERR! Did you mean one of these?
npm ERR!     build:storybook
npm ERR!     storybook

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/cryptix/.npm/_logs/2018-12-08T14_48_39_833Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! nes.css@0.0.2 build: `npm run build:clean && npm run build:stylelint && npm run build:sass && npm run build:autoprefix && npm run build:cleancss && npm run build-storybook`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the nes.css@0.0.2 build script.
```