### PR TITLE
feat(textarea): add textarea component

### DIFF
--- a/docs/textarea.stories.js
+++ b/docs/textarea.stories.js
@@ -1,0 +1,18 @@
+import { storiesOf } from '@storybook/html'; // eslint-disable-line import/no-extraneous-dependencies
+import { // eslint-disable-line import/no-extraneous-dependencies
+  withKnobs, radios,
+} from '@storybook/addon-knobs';
+
+const stories = storiesOf('Textareas', module);
+stories.addDecorator(withKnobs);
+
+stories.add('textarea', () => {
+  const selectedClass = radios('class', {
+    default: '',
+    'is-success': 'is-success',
+    'is-warning': 'is-warning',
+    'is-error': 'is-error',
+  }, '');
+
+  return `<textarea id="textarea_field" class="textarea ${selectedClass}" placeholder="NES.css">`;
+});

--- a/docs/textarea.stories.js
+++ b/docs/textarea.stories.js
@@ -14,5 +14,5 @@ stories.add('textarea', () => {
     'is-error': 'is-error',
   }, '');
 
-  return `<textarea id="textarea_field" class="textarea ${selectedClass}" placeholder="NES.css">`;
+  return `<textarea id="textarea_field" class="textarea ${selectedClass}" placeholder="NES.css"></textarea>`;
 });

--- a/index.html
+++ b/index.html
@@ -112,6 +112,10 @@
         <label for="error_field">.input.is-error</label>
         <input type="text" id="error_field" class="input is-error" placeholder="awesome.css">
       </div>
+      <div class="field">
+        <label for="textarea_field">Textarea</label>
+        <textarea id="textarea_field" class="textarea">
+      </div>
     </section>
 
     <section class="balloon container with-title">

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
       </div>
       <div class="field">
         <label for="textarea_field">Textarea</label>
-        <textarea id="textarea_field" class="textarea">
+        <textarea id="textarea_field" class="textarea"></textarea>
       </div>
     </section>
 

--- a/scss/form/inputs.scss
+++ b/scss/form/inputs.scss
@@ -1,4 +1,5 @@
-.input {
+.input,
+.textarea {
   @mixin border-style($border, $outline) {
     outline-color: $outline;
     // prettier-ignore
@@ -31,7 +32,8 @@
   > label {
     display: block;
   }
-  .input {
+  .input,
+  .textarea {
     display: block;
   }
 
@@ -47,7 +49,8 @@
       text-align: right;
     }
 
-    .input {
+    .input,
+    .textarea {
       flex-basis: 0;
       flex-grow: 5;
     }


### PR DESCRIPTION
This PR is to set the HTML5 `<textarea>` the same style as the inputs. So I just added the textarea class to inputs and a new textarea storybook.

If the users are supposed to use the input class and not this new `textarea` class, **this PR must be rejected**. 

I just think it will be more intuitive to use this `textarea` class, and for future changes between inputs/textarea we could refactor and keep them in separate files.

![screencast-localhost-6006-2018 12 09-13-06-20](https://user-images.githubusercontent.com/22016005/49699064-665eb280-fbb3-11e8-9340-403f4209dfc9.gif)
