### PR TITLE
Soften `commitlint` rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,13 +70,16 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "subject-case": [0, "never", "sentence-case"],
+      "subject-full-stop": [0, "never", "."]
+    }
   },
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged",
-      "prepare-commit-msg": "npm run semantic-commitlint -- -h"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
I've softened the `commitlint` rules. Commit subjects can now start with a capital letter and/or end with a full stop (.). 😉