### PR TITLE
fix(icons): changed pokemons icons width and height

### DIFF
--- a/scss/pixel-arts/bulbasaur.scss
+++ b/scss/pixel-arts/bulbasaur.scss
@@ -26,8 +26,8 @@
 
   position: relative;
   display: inline-block;
-  width: $px * 16;
-  height: $px * 16;
+  width: $px * 20;
+  height: $px * 17;
 
   &::before {
     position: absolute;

--- a/scss/pixel-arts/charmander.scss
+++ b/scss/pixel-arts/charmander.scss
@@ -27,8 +27,8 @@
 
   position: relative;
   display: inline-block;
-  width: $px * 16;
-  height: $px * 16;
+  width: $px * 21;
+  height: $px * 18;
 
   &::before {
     position: absolute;

--- a/scss/pixel-arts/squirtle.scss
+++ b/scss/pixel-arts/squirtle.scss
@@ -26,8 +26,8 @@
 
   position: relative;
   display: inline-block;
-  width: $px * 14;
-  height: $px * 14;
+  width: $px * 21;
+  height: $px * 17;
 
   &::before {
     position: absolute;


### PR DESCRIPTION
This three pokémons icons have the wrong width/height.

![image](https://user-images.githubusercontent.com/22016005/49705699-625c8000-fc07-11e8-855c-a97a60b8af51.png)

This PR is to fix it:

![image](https://user-images.githubusercontent.com/22016005/49705723-89b34d00-fc07-11e8-875e-9ad3c62981d9.png)

