### PR TITLE
[#196] use https instead of http

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,14 +99,14 @@
     <section class="nes-container with-title">
       <h2 class="title">Avatars</h2>
       <div>
-        <img src="http://www.gravatar.com/avatar" class="nes-avatar is-small">
-        <img src="http://www.gravatar.com/avatar" class="nes-avatar">
-        <img src="http://www.gravatar.com/avatar" class="nes-avatar is-medium">
-        <img src="http://www.gravatar.com/avatar" class="nes-avatar is-large">
-        <img src="http://www.gravatar.com/avatar" class="nes-avatar is-small is-rounded">
-        <img src="http://www.gravatar.com/avatar" class="nes-avatar is-rounded">
-        <img src="http://www.gravatar.com/avatar" class="nes-avatar is-medium is-rounded">
-        <img src="http://www.gravatar.com/avatar" class="nes-avatar is-large is-rounded">
+        <img src="https://www.gravatar.com/avatar" class="nes-avatar is-small">
+        <img src="https://www.gravatar.com/avatar" class="nes-avatar">
+        <img src="https://www.gravatar.com/avatar" class="nes-avatar is-medium">
+        <img src="https://www.gravatar.com/avatar" class="nes-avatar is-large">
+        <img src="https://www.gravatar.com/avatar" class="nes-avatar is-small is-rounded">
+        <img src="https://www.gravatar.com/avatar" class="nes-avatar is-rounded">
+        <img src="https://www.gravatar.com/avatar" class="nes-avatar is-medium is-rounded">
+        <img src="https://www.gravatar.com/avatar" class="nes-avatar is-large is-rounded">
       </div>
     </section>
 


### PR DESCRIPTION
fix #196

<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**
Demo site has error that mixed content.
so I used `https` instead of `http`.

**Compatibility**
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->
not include breaking.

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->
