### PR TITLE
fix: Fix the script that's run by `semantic-release`

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
       "@semantic-release/npm",
       "@semantic-release/github",
       ["@semantic-release/exec", {
-        "prepareCmd": "./scripts/update-version ${nextRelease.version}"
+        "prepareCmd": "./scripts/updatePackageHeader.js ${nextRelease.version}"
       }]
     ]
   },


### PR DESCRIPTION
I did a dumb. I changed the name of he script that updates the package headers before a release, but
I didn't tell `semantic-release-exec` that I'd changed it. 😬