### PR TITLE
fix(dialog): Fix dialog corners

### DIFF
--- a/docs/dialogs.stories.js
+++ b/docs/dialogs.stories.js
@@ -8,8 +8,10 @@ stories.addDecorator(withKnobs);
 
 stories.add('dialog', () => {
   const open = boolean('open', true) ? 'open' : '';
+  const isRounded = boolean('is-rounded', false) ? 'is-rounded' : '';
+  const selectedClasses = [isRounded];
 
-  return `<dialog ${open}>
+  return `<dialog class="nes-dialog ${selectedClasses.join(' ')}" ${open}>
       <p class="title">Dialog</p>
       <p>Alert: this is a dialog.</p>
   </div>`;

--- a/scss/elements/_index.scss
+++ b/scss/elements/_index.scss
@@ -1,11 +1,12 @@
 @charset "utf-8";
 
-@import "buttons.scss";
-@import "containers.scss";
-@import "radios.scss";
-@import "checkboxes.scss";
-@import "lists.scss";
-@import "balloons.scss";
-@import "tables.scss";
-@import "progress.scss";
 @import "avatar.scss";
+@import "balloons.scss";
+@import "buttons.scss";
+@import "checkboxes.scss";
+@import "containers.scss";
+@import "dialogs.scss";
+@import "lists.scss";
+@import "progress.scss";
+@import "radios.scss";
+@import "tables.scss";

--- a/scss/elements/dialogs.scss
+++ b/scss/elements/dialogs.scss
@@ -11,8 +11,7 @@
   }
 
   &.is-rounded {
-    color: $base-color;
     border: none;
-    box-shadow: 4px 0, -4px 0, 0 4px, 0 -4px;
+    box-shadow: 4px 0 $base-color, -4px 0 $base-color, 0 4px $base-color, 0 -4px $base-color;
   }
 }

--- a/scss/elements/dialogs.scss
+++ b/scss/elements/dialogs.scss
@@ -1,8 +1,5 @@
 .nes-dialog {
   padding: 1.5rem 2rem;
-  color: $base-color;
-  border: none;
-  box-shadow: 4px 0, -4px 0, 0 4px, 0 -4px;
 
   > .backdrop,
   &::backdrop {
@@ -11,5 +8,11 @@
 
   > :last-child {
     margin-bottom: 0;
+  }
+
+  &.is-rounded {
+    color: $base-color;
+    border: none;
+    box-shadow: 4px 0, -4px 0, 0 4px, 0 -4px;
   }
 }


### PR DESCRIPTION
**Description**
The dialog styles added by @sophi-est weren't being loaded into the compiled stylesheet. I've added
them to the elements index file and moved the rounded corners styles into and `.is-rounded` modifier
class.

**Compatibility**
This restores functionality that was lost, does not remove or break other functionality.

**Caveats**
The rounded corners for `<dialog />` components necessarily *are not* the same as `.container` components. This is because `<dialog />` elements are intended to be displayed over top of other elements and, with the way we create pixelated corners currently, the `<dialog />` component can't receive a background color.

**Testing Instructions**
1. Load Storybook (`npm run storybook`)
1. Verify that `<dialog />` components still work
1. Verify that the `<dialog />` component's `.is-rounded` state modifier works as expected.
1. ???
1. Profit