### PR TITLE
perf: Speed up pre-commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,12 +95,10 @@
   },
   "lint-staged": {
     "scss/**/*.scss": [
-      "npm run build",
-      "git add"
+      "npm run build:stylelint"
     ],
     "*.js": [
-      "eslint '.storybook/**/*.js' 'docs/**/*.js'",
-      "git add"
+      "eslint '.storybook/**/*.js' 'docs/**/*.js'"
     ]
   },
   "prettier": {


### PR DESCRIPTION
**Description**
We no longer need to build the entire framework to lint it, so I've removed the build step from the
pre-commit hook and replaced it with just stylelint.