### PR TITLE
Fix: mario icon on index.html and one line indent

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
       <section class="nes-container with-title">
         <h3 class="title">Others</h3>
         <div>
-            <i class="nes-icon close is-small"></i>
+          <i class="nes-icon close is-small"></i>
           <i class="nes-icon close"></i>
           <i class="nes-icon close is-medium"></i>
           <i class="nes-icon close is-large"></i>

--- a/scss/pixel-arts/_index.scss
+++ b/scss/pixel-arts/_index.scss
@@ -6,12 +6,12 @@
 @import "snes-jp-icon.scss";
 @import "bcrikko.scss";
 @import "ash.scss";
-@import "octocat.scss";
-@import "mario.scss";
 @import "pokeball.scss";
 @import "bulbasaur.scss";
 @import "charmander.scss";
 @import "squirtle.scss";
 @import "phone.scss";
 @import "smartphone.scss";
+@import "mario.scss";
 @import "kirby.scss";
+@import "octocat.scss";


### PR DESCRIPTION
**Description**
This fix the position of the mario icon for the `index.html`

**Compatibility**
This will only work when we launch the next release

**Caveats**
To test, in `index.html` change this:

```html
<link href="https://unpkg.com/nes.css/css/nes.min.css" rel="stylesheet" />
```

to this:

```html
<link href="./css/nes.min.css" rel="stylesheet" />
```

And run the `npm run build`, then check `index.html` icons section.

For some reason the first icon imported after `octocat.scss` got bugged and moved to the upper-left corner, so for now I just moved the `octocat.scss` to the last import. So this is isn't really a major fix, but I will investigate more later.