### PR TITLE
fix(readme-pt-br): change path of the contributing link

### DIFF
--- a/.github/README-pt-BR.md
+++ b/.github/README-pt-BR.md
@@ -96,7 +96,7 @@ Se você quiser nos ajudar com o projeto, nós agradecemos contribuições de to
 
 [commitizen]: http://commitizen.github.io/cz-cli/
 [commitizen-badge]: https://img.shields.io/badge/commitizen-friendly-brightgreen.svg
-[contributing-document]: .github/CONTRIBUTING-pt-BR.md
+[contributing-document]: ./CONTRIBUTING-pt-BR.md
 [gitter]: https://gitter.im/nostalgic-css/Lobby
 [gitter-badge]: https://img.shields.io/gitter/room/nostalgic-css/Lobby.svg
 [google-fonts-guide]: https://developers.google.com/fonts/docs/getting_started


### PR DESCRIPTION
**Description**
The link in `README-pt-BR.md` to `CONTRIBUTING-pt-BR.md` is broken

**Compatibility**
N/A

**Caveats**
N/A
