### PR TITLE
feat(text colors): adds text colors classes like is-primary etc.

### DIFF
--- a/docs/text.stories.js
+++ b/docs/text.stories.js
@@ -1,0 +1,19 @@
+import { storiesOf } from '@storybook/html'; // eslint-disable-line import/no-extraneous-dependencies
+import { // eslint-disable-line import/no-extraneous-dependencies
+  withKnobs, radios,
+} from '@storybook/addon-knobs';
+
+const stories = storiesOf('Text', module);
+stories.addDecorator(withKnobs);
+
+stories.add('text', () => {
+  const extraClass = radios('class', {
+    default: '',
+    'is-primary': 'is-primary',
+    'is-success': 'is-success',
+    'is-warning': 'is-warning',
+    'is-error': 'is-error',
+    'is-disabled': 'is-disabled',
+  }, '');
+  return `<span class="nes-text ${extraClass}">NES.css</span>`;
+});

--- a/scss/elements/_index.scss
+++ b/scss/elements/_index.scss
@@ -10,3 +10,4 @@
 @import "progress.scss";
 @import "radios.scss";
 @import "tables.scss";
+@import "text.scss";

--- a/scss/elements/text.scss
+++ b/scss/elements/text.scss
@@ -1,0 +1,17 @@
+.nes-text {
+  &.is-primary {
+    color: map-get($primary-colors, "normal");
+  }
+
+  &.is-success {
+    color: map-get($success-colors, "normal");
+  }
+
+  &.is-warning {
+    color: map-get($warning-colors, "normal");
+  }
+
+  &.is-error {
+    color: map_get($error-colors, "normal");
+  }
+}


### PR DESCRIPTION
Fixes #226

<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**
This PR adds text colors like `is-primary` etc.
To use those colors the text element must also add the class `nes-text`.

**Compatibility**
It isn't breaking
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->
