### PR TITLE
fix(container): removed padding-top inside with-title class

### DIFF
--- a/scss/elements/balloons.scss
+++ b/scss/elements/balloons.scss
@@ -1,11 +1,11 @@
 .nes-balloon {
   @include rounded-corners();
+
   position: relative;
   display: inline-block;
   padding: 1rem 1.5rem;
   margin: 8px;
   margin-bottom: 30px;
-
   background-color: $background-color;
 
   > :last-child {

--- a/scss/elements/containers.scss
+++ b/scss/elements/containers.scss
@@ -18,8 +18,6 @@
   }
 
   &.with-title {
-    padding-top: 2rem;
-
     > .title {
       display: table;
       padding: 0 0.5rem;

--- a/scss/elements/progress.scss
+++ b/scss/elements/progress.scss
@@ -1,11 +1,11 @@
 .nes-progress {
   @include compact-rounded-corners();
+
   width: 100%;
   height: 48px;
   margin: 4px;
   color: $base-color;
   background-color: $background-color;
-
   -webkit-appearance: none;
   appearance: none;
 

--- a/scss/form/selects.scss
+++ b/scss/form/selects.scss
@@ -16,12 +16,12 @@
 
   select {
     @include compact-rounded-corners();
+
     width: 100%;
     padding: 0.5rem 2.5rem 0.5rem 1rem;
     cursor: $cursor-click-url, pointer;
     border-radius: 0;
     outline-color: map-get($default-colors, "hover");
-
     -webkit-appearance: none;
     appearance: none;
 


### PR DESCRIPTION
**Description**
This PR is to fix only the `with-title` bug at #235 

**Compatibility**
N/A

![image](https://user-images.githubusercontent.com/22016005/50615421-a459a880-0ecb-11e9-815c-19527522b567.png)


**Caveats**
One thing here, I notice that the containers in https://nostalgic-css.github.io/NES.css/ is more rounded than the ones in develop. Not sure if that was intended.
