### PR TITLE
Adds Input-File feature.

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,6 +165,16 @@
           </div>
         </div>
       </div>
+      <div>
+        <p>File</p>
+        <br />
+        <form>
+          <label for="nes-file-btn" class="nes-btn">
+            Upload File
+          </label>
+          <input type="file" id="nes-file-btn">
+        </form>
+      </div>
     </section>
 
     <section class="balloon nes-container with-title">

--- a/scss/base/generic.scss
+++ b/scss/base/generic.scss
@@ -41,3 +41,8 @@ input[type="radio"],
 input[type="checkbox"] {
   outline: 0;
 }
+
+// Hides the default <input type="file"> upload button. A <label> targeting the id of the now hidden input is required.
+input[type="file"] {
+  display: none;
+}


### PR DESCRIPTION
This adds styling to hide the default Input for File Uploads and an example to the index page for targeting the now hidden File Upload button with a label element which can be styled to appear like other nes.css buttons.

**Description**
This hides the default <input type="file"> element. This allows the use of a <label> element to target the id of the now hidden input which can be styled to appear like an nes.css button.

**Compatibility**
This feature only targets the "file" input type. File input elements used without a corresponding label element will not be visible. 

**Caveats**
<input type="file"> elements must include a unique id and be used with a <label> element which targets that same id for this functionality to be effective. The label element can then be styled with the nes-btn class to appear like other nes.css buttons.
