### PR TITLE
[#255] Dark mode for checkbox

### DIFF
--- a/docs/inputs.stories.js
+++ b/docs/inputs.stories.js
@@ -14,11 +14,19 @@ stories.add('input.radio', () => `
         <input type="radio" class="nes-radio" name="answer" />
         <span>No</span>
       </label>`)
-  .add('input.checkbox', () => `
-      <label>
-        <input type="checkbox" class="nes-checkbox" checked />
+  .add('input.checkbox', () => {
+    const selectedClass = radios('class', {
+      default: '',
+      'is-dark': 'is-dark',
+    }, '');
+
+    return (
+      `<label>
+        <input type="checkbox" class="nes-checkbox ${selectedClass}" checked />
         <span>Enable</span>
-      </label>`)
+      </label>`
+    );
+  })
   .add('input', () => {
     const selectedClass = radios('class', {
       default: '',

--- a/scss/form/checkboxes.scss
+++ b/scss/form/checkboxes.scss
@@ -46,6 +46,7 @@
     (2,2,2,2,2,2,2,2,0,0)
   );
   $colors: ($base-color, map-get($default-colors, "shadow"));
+  $colors-checkbox-dark: ($color-white, map-get($default-colors, "shadow"));
 
   margin-left: 28px;
   -webkit-appearance: none;
@@ -79,5 +80,25 @@
   }
   &:checked:focus + span::before {
     @include pixelize(2px, $checkbox-checked-focus, $colors);
+  }
+  &.is-dark {
+    + span {
+      color: $color-white;
+    }
+    // prettier-ignore
+    + span::before { /* stylelint-disable-line no-descending-specificity */
+      color: $color-white;
+    }
+
+    &:checked + span::before {
+      @include pixelize(2px, $checkbox-checked-focus, $colors-checkbox-dark);
+
+      color: $color-white;
+    }
+    &:checked:focus + span::before {
+      @include pixelize(2px, $checkbox-checked-focus, $colors-checkbox-dark);
+
+      color: $color-white;
+    }
   }
 }


### PR DESCRIPTION
<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->
## Fix: #255 

**Description**
<!-- What does this PR do, what does it want to achieve? -->
We need to add styles when the checkbox is on dark mode, currently, the
checkbox is not visible at all if the container is dark.

**Compatibility**
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->
Now we can to add the class `is-dark` to a `nes-checkbox` element.

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->
Not yet.
