### PR TITLE
fix(radios.scss): Fix flash when selecting radios

### DIFF
--- a/scss/elements/radios.scss
+++ b/scss/elements/radios.scss
@@ -44,7 +44,11 @@
   &:checked:hover,
   &:checked:focus {
     & + span::before {
-      animation: blink 1s infinite steps(1);
+      animation-name: blink;
+      animation-duration: 1s;
+      animation-timing-function: steps(1);
+      animation-iteration-count: infinite;
+      animation-fill-mode: both;
     }
   }
 


### PR DESCRIPTION
When switching radio buttons, the caret for the previously selected option would flash black for a
moment before switching to the new radio. I've fixed that by adding `animation-fill-mode: both;`.