### PR TITLE
fix border bugs on chrome

### DIFF
--- a/scss/form/inputs.scss
+++ b/scss/form/inputs.scss
@@ -1,17 +1,16 @@
 .nes-input,
 .nes-textarea {
   @mixin border-style($border, $outline) {
-    @include compact-rounded-corners();
     @include compact-border-image($border);
 
     outline-color: $outline;
   }
 
+  @include compact-rounded-corners();
+
   width: 100%;
   padding: 0.5rem 1rem;
   margin: 4px;
-
-  @include border-style($base-color, map-get($default-colors, "hover"));
 
   &.is-dark {
     @include border-style(map-get($default-colors, "normal"), map-get($default-colors, "hover"));

--- a/scss/utilities/rounded-corners-mixin.scss
+++ b/scss/utilities/rounded-corners-mixin.scss
@@ -16,6 +16,7 @@
 
   border-image-slice: 3;
   border-image-width: 3;
+  border-image-repeat: space;
 
   @if $isDark {
     @include border-image($color-white);
@@ -33,6 +34,7 @@
 
   border-image-slice: 2;
   border-image-width: 2;
+  border-image-repeat: space;
 
   @if $isDark {
     @include compact-border-image($color-white);


### PR DESCRIPTION
border is broken when zooming in/out on chrome

fix #244

**Description**
`border-image` using Inline SVG is broken when zooming in/out on chome.

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/22016005/52128079-21875300-261b-11e9-98f2-0d57a72acecc.png)|![2019-02-05 20 37 34](https://user-images.githubusercontent.com/5305599/52271032-e9b73d00-2985-11e9-9b89-ee09f5368161.png)|

**Compatibility**
N/A

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->
