### PR TITLE
feat(text): added is-disabled to text. changed text to texts.

### DIFF
--- a/docs/select.stories.js
+++ b/docs/select.stories.js
@@ -3,7 +3,7 @@ import { // eslint-disable-line import/no-extraneous-dependencies
   withKnobs, radios,
 } from '@storybook/addon-knobs';
 
-const stories = storiesOf('Select', module);
+const stories = storiesOf('Selects', module);
 stories.addDecorator(withKnobs);
 
 stories.add('select', () => {

--- a/docs/text.stories.js
+++ b/docs/text.stories.js
@@ -3,7 +3,7 @@ import { // eslint-disable-line import/no-extraneous-dependencies
   withKnobs, radios,
 } from '@storybook/addon-knobs';
 
-const stories = storiesOf('Text', module);
+const stories = storiesOf('Texts', module);
 stories.addDecorator(withKnobs);
 
 stories.add('text', () => {

--- a/scss/elements/text.scss
+++ b/scss/elements/text.scss
@@ -14,4 +14,8 @@
   &.is-error {
     color: map_get($error-colors, "normal");
   }
+
+  &.is-disabled {
+    color: map_get($disabled-colors, "normal");
+  }
 }


### PR DESCRIPTION
**Description**
This PR adds `is-disabled` to `Text`, because it had in `text.stories.js` but it was doing nothing, and I put it in #278 :smile: 

**Compatibility**
N/A

**Caveats**
I've also changed the module name in storybooks from `Text` to `Texts` and from `Select` to `Selects`.

![image](https://user-images.githubusercontent.com/22016005/52512950-d529ad80-2bee-11e9-8b7f-3e71e131d4ac.png)
