### PR TITLE
fix(dialog): fix dialogs is-dark white border missing.

### DIFF
--- a/scss/elements/dialogs.scss
+++ b/scss/elements/dialogs.scss
@@ -22,7 +22,7 @@
     background-color: $base-color;
     border-color: $background-color;
 
-    &::after {
+    &:not(.is-rounded)::after {
       position: absolute;
       top: -$border-size * 1.8;
       right: -$border-size * 1.8;

--- a/scss/elements/dialogs.scss
+++ b/scss/elements/dialogs.scss
@@ -21,5 +21,16 @@
     color: $background-color;
     background-color: $base-color;
     border-color: $background-color;
+
+    &::after {
+      position: absolute;
+      top: -$border-size * 1.8;
+      right: -$border-size * 1.8;
+      bottom: -$border-size * 1.8;
+      left: -$border-size * 1.8;
+      z-index: -1;
+      content: "";
+      background-color: $base-color;
+    }
   }
 }


### PR DESCRIPTION
ref #281. 

**Description**
This PR fix the `is-dark` dialog white border, because it don't have an `after` like the `Container` component.

Before this PR:

![image](https://user-images.githubusercontent.com/22016005/52513114-dad3c300-2bef-11e9-8578-1a176d142747.png)

After this PR:

![image](https://user-images.githubusercontent.com/22016005/52513120-e58e5800-2bef-11e9-88d8-48b564050d49.png)


**Compatibility**
N/A

**Caveats**
N/A
