### PR TITLE
fix(icon-mixin.scss): fix style on firefox

### DIFF
--- a/scss/utilities/icon-mixin.scss
+++ b/scss/utilities/icon-mixin.scss
@@ -38,10 +38,10 @@
         $color: nth($colors, $dot);
         @if $color == $default-color {
           $ret: $ret + ($j * $size) + " " + ($i * $size);
-          $moz: $moz + ($j * $size) + " " + ($i * $size) + "0 0.020px";
+          $moz: $moz + ($j * $size) + " " + ($i * $size) + " 0 0.020em";
         } @else {
-          $ret: $ret + ($j * $size) + " " + ($i * $size) + "" + $color;
-          $moz: $moz + ($j * $size) + " " + ($i * $size) + "0 0.020px " + $color;
+          $ret: $ret + ($j * $size) + " " + ($i * $size) + " " + $color;
+          $moz: $moz + ($j * $size) + " " + ($i * $size) + " 0 0.020em " + $color;
         }
       }
     }
@@ -51,7 +51,9 @@
   height: $size;
   color: $default-color;
   box-shadow: unquote($ret);
-  @-moz-document url-prefix() {
-    -webkit-box-shadow: unquote($moz);
+
+  // firefox only style
+  @supports (-moz-appearance: meterbar) {
+    box-shadow: unquote($moz);
   }
 }


### PR DESCRIPTION
use `@supports (-moz-appearance: meterbar)` instead of `@-moz-document url-prefix()`

<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**
I fixed style for firefox.
https://bugzilla.mozilla.org/show_bug.cgi?id=1035091

**Compatibility**
not

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->
