### PR TITLE
[#301] Fix blurred borders in safari

### DIFF
--- a/scss/utilities/rounded-corners-mixin.scss
+++ b/scss/utilities/rounded-corners-mixin.scss
@@ -16,7 +16,7 @@
 
   border-image-slice: 3;
   border-image-width: 3;
-  border-image-repeat: space;
+  border-image-repeat: stretch;
 
   @if $isDark {
     @include border-image($color-white);
@@ -34,7 +34,7 @@
 
   border-image-slice: 2;
   border-image-width: 2;
-  border-image-repeat: space;
+  border-image-repeat: stretch;
 
   @if $isDark {
     @include compact-border-image($color-white);

--- a/scss/utilities/rounded-corners-mixin.scss
+++ b/scss/utilities/rounded-corners-mixin.scss
@@ -16,7 +16,7 @@
 
   border-image-slice: 3;
   border-image-width: 3;
-  border-image-repeat: stretch;
+  border-image-repeat: space;
 
   @if $isDark {
     @include border-image($color-white);

--- a/scss/utilities/rounded-corners-mixin.scss
+++ b/scss/utilities/rounded-corners-mixin.scss
@@ -16,7 +16,7 @@
 
   border-image-slice: 3;
   border-image-width: 3;
-  border-image-repeat: space;
+  border-image-repeat: stretch;
 
   @if $isDark {
     @include border-image($color-white);


### PR DESCRIPTION
<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**

I've changed the property of the `border-image-repeat` to stretch this fixes the bug in safari, and fixes the sliced borders in firefox too (#273) 👍 

**Compatibility**
tested in:
Chrome: 72.0.3626.119
Safari: 12.0
Firefox: 65.0.1