### PR TITLE
fix: remove input shadow on ios

### DIFF
--- a/scss/form/inputs.scss
+++ b/scss/form/inputs.scss
@@ -11,6 +11,7 @@
   width: 100%;
   padding: 0.5rem 1rem;
   margin: 4px;
+  background-clip: padding-box;
 
   &.is-dark {
     @include border-style(map-get($default-colors, "normal"), map-get($default-colors, "hover"));


### PR DESCRIPTION
**Description**
Remove the input and textarea shadow on Iphone and Ipad.
<img width="374" alt="Screen Shot 2019-03-30 at 20 40 00" src="https://user-images.githubusercontent.com/14945222/55283045-32f58e80-5330-11e9-84aa-7eb3ad3ec3ae.png">
<img width="373" alt="Screen Shot 2019-03-30 at 20 40 11" src="https://user-images.githubusercontent.com/14945222/55283046-32f58e80-5330-11e9-8d53-3c89ed57e656.png">

**Compatibility**
iOS 10+
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->
