### PR TITLE
fix: remove underline in hover and set color

### DIFF
--- a/scss/elements/buttons.scss
+++ b/scss/elements/buttons.scss
@@ -14,6 +14,8 @@
 
   &:hover,
   &:focus {
+    color: inherit;
+    text-decoration: none;
     background-color: $hover-background;
 
     &::after {


### PR DESCRIPTION
resolves #328 

Description

When used `.nes-btn` in a tag `a` in the `hover` is added a underline and color in the text.