### PR TITLE
Add select is-dark class type like input component

### DIFF
--- a/scss/form/selects.scss
+++ b/scss/form/selects.scss
@@ -30,6 +30,11 @@
     }
   }
 
+  &.is-dark select {
+    color: $background-color;
+    background-color: $base-color;
+  }
+
   &::after {
     @include pixelize(3px, $dropdown, $colors);
 
@@ -44,7 +49,8 @@
   $types:
     "success" map-get($success-colors, "normal") map-get($success-colors, "hover"),
     "warning" map-get($warning-colors, "normal") map-get($warning-colors, "hover"),
-    "error" map-get($error-colors, "normal") map-get($error-colors, "hover");
+    "error" map-get($error-colors, "normal") map-get($error-colors, "hover"),
+    "dark" map-get($default-colors, "normal") map-get($default-colors, "hover");
 
   @each $type in $types {
     &.is-#{nth($type, 1)} {

--- a/story/select.stories.js
+++ b/story/select.stories.js
@@ -12,6 +12,7 @@ stories.add('select', () => {
     'is-success': 'is-success',
     'is-warning': 'is-warning',
     'is-error': 'is-error',
+    'is-dark': 'is-dark',
   }, '');
 
   return `


### PR DESCRIPTION
**Description**
This PR adds a `is-dark` class to `nes-select` and solves #334.

**Compatibility**
This should not break anything.

**Caveats**
N/A.
