### PR TITLE
feat: add the new nes-cursor class

### DIFF
--- a/scss/helpers/_index.scss
+++ b/scss/helpers/_index.scss
@@ -1,0 +1,3 @@
+@charset "utf-8";
+
+@import "pointer.scss";

--- a/scss/helpers/pointer.scss
+++ b/scss/helpers/pointer.scss
@@ -1,0 +1,3 @@
+.nes-pointer {
+  cursor: $cursor-click-url, pointer;
+}

--- a/scss/nes.scss
+++ b/scss/nes.scss
@@ -4,3 +4,4 @@
 @import "components/_index.scss";
 @import "icons/_index.scss";
 @import "pixel-arts/_index.scss";
+@import "helpers/_index.scss"


### PR DESCRIPTION
**Description**
This PR will add an easy way to access the custom cursor that this library uses by adding a `nes-pointer` class

**Compatibility**
It only adds a new class, so it should be fully compatible

**Caveats**
I added some new sccs files based on the suggested path found in issue #339 
