### PR TITLE
Fix focus color of buttons

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -11,7 +11,7 @@ const sampleCollection = [
   {
     title: 'buttons',
     showCode: false,
-    code: `<a class="nes-btn">Normal</a>
+    code: `<a class="nes-btn" href="#">Normal</a>
 
 <button type="button" class="nes-btn is-primary">Primary</button>
 <button type="button" class="nes-btn is-success">Success</button>

--- a/scss/elements/buttons.scss
+++ b/scss/elements/buttons.scss
@@ -12,8 +12,7 @@
     box-shadow: inset -4px -4px $shadow;
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     color: inherit;
     text-decoration: none;
     background-color: $hover-background;
@@ -21,6 +20,10 @@
     &::after {
       box-shadow: inset -6px -6px $shadow;
     }
+  }
+
+  &:focus {
+    box-shadow: 0 0 0 6px rgba($shadow, 0.3);
   }
 
   &:active:not(.is-disabled)::after {


### PR DESCRIPTION
fix #74

<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**
I splitted the style into `:hover` and `:focus`.
https://github.com/nostalgic-css/NES.css/issues/74#issuecomment-500655038

**Compatibility**
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->
no

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->
no