### PR TITLE
Add now.json to deploy PRs

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,10 @@
+{
+  "name": "NES.css",
+  "version": 2,
+  "builds": [
+    { "src": "docs/**", "use": "@now/static" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "/docs/$1" }
+  ]
+}


### PR DESCRIPTION
**Description**
Add a `now.json` config file so that PRs are deployed to ZEIT Now hosting.

This will require creating an account and adding the integration here: https://zeit.co/github

You can see how it looks by viewing existing PRs here: https://github.com/markedjs/marked

**Compatibility**
None. However you can get a nicer domain name for free such as nes.now.sh if you like.

**Caveats**
Takes a minute to setup but then there is no need to touch it after that.
