### PR TITLE
feat(component-balloons): Dark Mode - Balloons

### DIFF
--- a/scss/elements/balloons.scss
+++ b/scss/elements/balloons.scss
@@ -1,3 +1,27 @@
+@mixin box-shadow($color, $fromLeft: true) {
+  @if $fromLeft {
+    // prettier-ignore
+    box-shadow:
+      -4px 0,
+      4px 0,
+      -4px 4px $color,
+      0 4px,
+      -8px 4px,
+      -4px 8px,
+      -8px 8px;
+  } @else {
+    // prettier-ignore
+    box-shadow:
+      -4px 0,
+      4px 0,
+      4px 4px $color,
+      0 4px,
+      8px 4px,
+      4px 8px,
+      8px 8px;
+  }
+}
+
 .nes-balloon {
   @include rounded-corners();
 
@@ -16,6 +40,45 @@
   &::after {
     position: absolute;
     content: "";
+  }
+
+  &.is-dark {
+    @include rounded-corners(true);
+    background: $base-color;
+    color: $background-color;
+    border-image-outset: 2;
+    box-shadow: 0px 0px 0 8px $base-color;
+
+    &.from-left,
+    &.from-right {
+      &::before {
+        background-color: $base-color;
+        border-color: $background-color;
+      }
+
+      &::after {
+        color: $background-color;
+        background-color: $base-color;
+      }
+    }
+
+    &.from-left {
+      &::before {
+        box-shadow: -5px 10px 0 6px $base-color;
+      }
+      &::after {
+        @include box-shadow($base-color);
+      }
+    }
+
+    &.from-right {
+      &::before {
+        box-shadow: 5px 10px 0 6px $base-color;
+      }
+      &::after {
+        @include box-shadow($base-color, false);
+      }
+    }
   }
 
   &.from-left {
@@ -40,15 +103,7 @@
       margin-right: 8px;
       color: $base-color;
       background-color: $background-color;
-      // prettier-ignore
-      box-shadow:
-        -4px 0,
-        4px 0,
-        -4px 4px $background-color,
-        0 4px,
-        -8px 4px,
-        -4px 8px,
-        -8px 8px;
+      @include box-shadow($background-color);
     }
   }
 
@@ -73,15 +128,7 @@
       height: 4px;
       margin-left: 8px;
       background-color: $background-color;
-      // prettier-ignore
-      box-shadow:
-        -4px 0,
-        4px 0,
-        4px 4px $background-color,
-        0 4px,
-        8px 4px,
-        4px 8px,
-        8px 8px;
+      @include box-shadow($background-color, false);
     }
   }
 }

--- a/story/balloons.stories.js
+++ b/story/balloons.stories.js
@@ -1,16 +1,18 @@
 import { storiesOf } from '@storybook/html'; // eslint-disable-line import/no-extraneous-dependencies
 import { // eslint-disable-line import/no-extraneous-dependencies
-  withKnobs, radios,
+  withKnobs, boolean, radios,
 } from '@storybook/addon-knobs';
 
 const stories = storiesOf('Ballons', module);
 stories.addDecorator(withKnobs);
 
 stories.add('balloon', () => {
-  const selectedClass = radios('direction', {
+  const isDark = boolean('is-dark', false) ? 'is-dark' : '';
+  const alignment = radios('direction', {
     default: '',
     'from-left': 'from-left',
     'from-right': 'from-right',
   }, '');
-  return `<div class="nes-balloon ${selectedClass}"> <p>Hello NES.css</p> </div>`;
+  const selectedClasses = [isDark, alignment];
+  return `<div class="nes-balloon ${selectedClasses.join(' ')}"> <p>Hello NES.css</p> </div>`;
 });


### PR DESCRIPTION
Implementation so balloons can now have `is-dark`

re #345

**Description**
Exactly what it says on the tin, I have added the ability for balloons to be displayed in dark mode.

__Screen:__
![image](https://user-images.githubusercontent.com/8589366/66675584-7fb20e80-ec5d-11e9-8e16-fa81de650a54.png)

**Compatibility**
Non-breaking, tis a small change. However I did add a mixin due to repeating scss.

**Caveats**
None
