### PR TITLE
UPT: add LTS version for node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "nes",
     "framework"
   ],
+  "engines": {
+    "node": "10.x"
+  },
   "author": "BcRikko (https://github.com/Bcrikko)",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Hi,

I think we should add the min version (e.g. LTS ) of the node engine for this package.

Best,
Alpha