### PR TITLE
feat(buttons): add storybook for input type file

### DIFF
--- a/story/buttons.stories.js
+++ b/story/buttons.stories.js
@@ -1,12 +1,16 @@
 import { storiesOf } from '@storybook/html'; // eslint-disable-line import/no-extraneous-dependencies
 import { // eslint-disable-line import/no-extraneous-dependencies
-  withKnobs, radios,
+  withKnobs, radios, select,
 } from '@storybook/addon-knobs';
 
 const stories = storiesOf('Buttons', module);
 stories.addDecorator(withKnobs);
 
 stories.add('button', () => {
+  const buttonType = select('type', {
+    button: 'button',
+    file: 'file',
+  }, 'button');
   const extraClass = radios('class', {
     default: '',
     'is-primary': 'is-primary',
@@ -15,5 +19,10 @@ stories.add('button', () => {
     'is-error': 'is-error',
     'is-disabled': 'is-disabled',
   }, '');
-  return `<button type="button" class="nes-btn ${extraClass}">Normal</button>`;
+  return buttonType === 'file'
+    ? `<label class="nes-btn ${extraClass}">
+      <span>Select your file</span>
+      <input type="file">
+    </label>`
+    : `<button type="button" class="nes-btn ${extraClass}">Normal</button>`;
 });


### PR DESCRIPTION
**Description**
This adds a story for input type file, by adding a `select` type knob to buttons, that can be toggled by button and file.

![image](https://user-images.githubusercontent.com/22016005/67005241-8fe04880-f0b8-11e9-8983-8e67a40f1eb5.png)


**Compatibility**
None.

**Caveats**
None, the classes (`is-primary`, etc.) are working too.
The default type is `button`.
