### PR TITLE
Add list is dark

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -261,7 +261,27 @@ const sampleCollection = [
     <li>Thou hast had a good afternoon</li>
     <li>Good night.</li>
   </ul>
-</div>`,
+</div>
+
+<section class="nes-container is-dark">
+  <div class="lists">
+    <ul class="nes-list is-disc is-dark">
+      <li>Good morning.</li>
+      <li>Thou hast had a good night's sleep, I hope.</li>
+      <li>Thou hast had a good afternoon</li>
+      <li>Good night.</li>
+    </ul>
+  </div>
+
+  <div class="lists">
+    <ul class="nes-list is-circle is-dark">
+      <li>Good morning.</li>
+      <li>Thou hast had a good night's sleep, I hope.</li>
+      <li>Thou hast had a good afternoon</li>
+      <li>Good night.</li>
+    </ul>
+  </div>
+</section>`,
   },
   {
     title: 'tables',

--- a/scss/elements/lists.scss
+++ b/scss/elements/lists.scss
@@ -1,3 +1,18 @@
+@mixin list-before(
+  $class,
+  $disc-or-circle,
+  $colors: ($base-color, map-get($default-colors, "shadow"))
+) {
+  &.is-#{$class} li::before {
+    position: absolute;
+    top: calc(50% - 8px);
+    left: -22px;
+    content: "";
+
+    @include pixelize(2px, $disc-or-circle, $colors);
+  }
+}
+
 .nes-list {
   // prettier-ignore
   $disc: (
@@ -18,7 +33,6 @@
     (0,0,1,1,1,1,0,0),
     (0,0,0,1,1,0,0,0)
   );
-  $colors: ($base-color, map-get($default-colors, "shadow"));
 
   list-style-type: none;
 
@@ -26,21 +40,16 @@
     position: relative;
   }
 
-  &.is-disc li::before {
-    position: absolute;
-    top: calc(50% - 8px);
-    left: -22px;
-    content: "";
+  @include list-before("disc", $disc);
+  @include list-before("circle", $circle);
 
-    @include pixelize(2px, $disc, $colors);
-  }
+  &.is-dark {
+    $dark-colors: ($background-color, $base-color);
+    @include list-before("disc", $disc, $dark-colors);
+    @include list-before("circle", $circle, $dark-colors);
 
-  &.is-circle li::before {
-    position: absolute;
-    top: calc(50% - 8px);
-    left: -22px;
-    content: "";
-
-    @include pixelize(2px, $circle, $colors);
+    li {
+      color: $color-white;
+    }
   }
 }

--- a/story/lists/lists.template.js
+++ b/story/lists/lists.template.js
@@ -1,7 +1,8 @@
-import { radios } from '@storybook/addon-knobs';
+import { radios, boolean } from '@storybook/addon-knobs';
 import classNames from 'classnames';
 
 export default () => {
+  const isDark = boolean('is-dark', false);
   const listOptions = radios('List Type', {
     'is-disc': 'is-disc',
     'is-circle': 'is-circle',
@@ -9,6 +10,9 @@ export default () => {
 
   const listClasses = classNames(
     'nes-list',
+    {
+      'is-dark': isDark,
+    },
     listOptions,
   );
 


### PR DESCRIPTION
ref #395 

**Description**
This PR adds `is-dark` to `nes-list`, to fix lists in dark containers.

**Compatibility**
I added a mixin and changed a little bit, but I don't think should break anything. Tested in green field browsers.

**Caveats**
Right now it looks like this, suggestions are welcomed.

![image](https://user-images.githubusercontent.com/22016005/73256861-7a8fb580-41a1-11ea-9e7e-d3df285854df.png)

![image](https://user-images.githubusercontent.com/22016005/73256888-83808700-41a1-11ea-8290-d407dccc6e1e.png)

![image](https://user-images.githubusercontent.com/22016005/73257006-c0e51480-41a1-11ea-8cb4-c9483431b17b.png)

![image](https://user-images.githubusercontent.com/22016005/73256915-92673980-41a1-11ea-98a4-ee5cd54bfa76.png)


