### PR TITLE
ci: change base image to fix commitlint error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,13 @@ defaults: &defaults
 
   working_directory: ~/app
 
-
-
-
-
 jobs:
   commitlint:
     docker:
-      - image: williamlauze/circleci-commitlint:latest
+      - image: secretbase/circleci-commitlint:1.0.2
     working_directory: ~/app
-
+    environment:
+      CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>..<<pipeline.git.revision>>
     steps:
       - checkout
       - run:
@@ -159,10 +156,6 @@ jobs:
       - run:
           name: Release
           command: npx semantic-release
-
-
-
-
 
 workflows:
   version: 2


### PR DESCRIPTION
Reopen the PR. Sorry for the noise.

https://github.com/nostalgic-css/NES.css/pull/424

@virtuoushub
@guastallaigor

instead of waiting for the upstream image updated. I decide to spend some time to run my own image. So others everyone can moving forward.

I fork the upstream base image and make some changes same as @virtuoushub opened PR for the upstream.

https://github.com/SecretBase/circleci-commitlint-step
https://hub.docker.com/r/secretbase/circleci-commitlint/tags