### PR TITLE
Remove Google Analytics

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,8 +31,6 @@
     <meta name="twitter:creator" content="@bc_rikko" />
     <meta name="twitter:image" content="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" />
 
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-41640153-4"></script>
-    <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag("js", new Date());gtag("config", "UA-41640153-4");</script>
     <script>
       if (window.navigator.userAgent.toLocaleLowerCase().indexOf('trident') !== -1) {
         window.alert('IE is not supported on this page.')


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/

<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Compatibility**
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->

Not breaking in any way.

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->

None.