### PR TITLE
Fixed spacing in pixels for message bubbles

### DIFF
--- a/scss/utilities/rounded-corners-mixin.scss
+++ b/scss/utilities/rounded-corners-mixin.scss
@@ -16,7 +16,7 @@
 
   // for chrome
   @media all and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: 0.001dpcm) {
-    border-image-repeat: space;
+    border-image-repeat: stretch;
   }
 
   // for firefox


### PR DESCRIPTION
<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**
<!-- What does this PR do, what does it want to achieve? -->
When pixels are odd there is the spacing between pixels. Chrome now gives the same behavior as other browsers when supplied the stretch property 
**Compatibility**
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->
This fixes a broken design element in chrome 
**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->