### PR TITLE
fix(button): disable hover of disabled button

### DIFF
--- a/scss/elements/buttons.scss
+++ b/scss/elements/buttons.scss
@@ -65,6 +65,10 @@
     opacity: 0.6;
   }
 
+  &.is-disabled:hover::after {
+    box-shadow: inset -4px -4px map-get($disabled-colors, "shadow");
+  }
+
   // Other styles
   // prettier-ignore
   $types:


### PR DESCRIPTION
<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**
<!-- What does this PR do, what does it want to achieve? -->
This PR overwrote the `box-shadow` of `.nes-btn.is-disabled:hover::after` so that the disabled button won't change upon hover.

Before this pr, the disabled button behaved like:

![2021-03-02 23 16 53](https://user-images.githubusercontent.com/10428324/109671933-7b1e2b00-7baf-11eb-8309-b9a4c578530a.gif)

After, it behaves like:

![2021-03-02 23 17 29](https://user-images.githubusercontent.com/10428324/109672025-925d1880-7baf-11eb-8cf7-27eb88ec17cb.gif)

Thank you for your time on reviewing this PR :).

**Compatibility**
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->
This should not break anything.

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->
None.

