### PR TITLE
docs: fix paths of  some localization markdown files

### DIFF
--- a/.github/CODE_OF_CONDUCT-es.md
+++ b/.github/CODE_OF_CONDUCT-es.md
@@ -1,7 +1,7 @@
 # Código de Conducta convenido para Contribuyentes
 
 Ver este documento en otro idioma:
-[English](CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [简体中文](.github/CONTRIBUTING-zh-CN.md) / [Português](.github/CONTRIBUTING-pt-BR.md)
+[English](/CODE_OF_CONDUCT.md) / [日本語](.github/CODE_OF_CONDUCT-jp.md) / [简体中文](.github/CODE_OF_CONDUCT-zh-CN.md) / [Português](.github/CODE_OF_CONDUCT-pt-BR.md)
 
 ## Nuestro compromiso
 

--- a/.github/CODE_OF_CONDUCT-es.md
+++ b/.github/CODE_OF_CONDUCT-es.md
@@ -1,7 +1,7 @@
 # Código de Conducta convenido para Contribuyentes
 
 Ver este documento en otro idioma:
-[English](/CODE_OF_CONDUCT.md) / [日本語](.github/CODE_OF_CONDUCT-jp.md) / [简体中文](.github/CODE_OF_CONDUCT-zh-CN.md) / [Português](.github/CODE_OF_CONDUCT-pt-BR.md)
+[English](/CODE_OF_CONDUCT.md) / [日本語](CODE_OF_CONDUCT-jp.md) / [简体中文](CODE_OF_CONDUCT-zh-CN.md) / [Português](CODE_OF_CONDUCT-pt-BR.md)
 
 ## Nuestro compromiso
 

--- a/.github/CODE_OF_CONDUCT-jp.md
+++ b/.github/CODE_OF_CONDUCT-jp.md
@@ -1,7 +1,7 @@
 # コントリビューター行動規範
 
 このドキュメントを別の言語で表示する：
-[English](/CODE_OF_CONDUCT.md) / [简体中文](.github/CODE_OF_CONDUCT-zh-CN.md) / [Español](.github/CODE_OF_CONDUCT-es.md) / [Português](.github/CODE_OF_CONDUCT-pt-BR.md)
+[English](/CODE_OF_CONDUCT.md) / [简体中文](CODE_OF_CONDUCT-zh-CN.md) / [Español](CODE_OF_CONDUCT-es.md) / [Português](CODE_OF_CONDUCT-pt-BR.md)
 
 ## 私たちの約束
 

--- a/.github/CODE_OF_CONDUCT-jp.md
+++ b/.github/CODE_OF_CONDUCT-jp.md
@@ -1,7 +1,7 @@
 # コントリビューター行動規範
 
 このドキュメントを別の言語で表示する：
-[English](CONTRIBUTING.md) / [简体中文](.github/CONTRIBUTING-zh-CN.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md)
+[English](/CODE_OF_CONDUCT.md) / [简体中文](.github/CODE_OF_CONDUCT-zh-CN.md) / [Español](.github/CODE_OF_CONDUCT-es.md) / [Português](.github/CODE_OF_CONDUCT-pt-BR.md)
 
 ## 私たちの約束
 

--- a/.github/CODE_OF_CONDUCT-pt-BR.md
+++ b/.github/CODE_OF_CONDUCT-pt-BR.md
@@ -1,7 +1,7 @@
 # Código de Conduta para Colaboradores
 
 Veja este documento em outro idioma:
-[English](CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [简体中文](.github/CONTRIBUTING-zh-CN.md) / [Español](.github/CONTRIBUTING-es.md)
+[English](/CODE_OF_CONDUCT.md) / [日本語](.github/CODE_OF_CONDUCT-jp.md) / [简体中文](.github/CODE_OF_CONDUCT-zh-CN.md) / [Español](.github/CODE_OF_CONDUCT-es.md)
 
 ## Nossa promessa
 

--- a/.github/CODE_OF_CONDUCT-pt-BR.md
+++ b/.github/CODE_OF_CONDUCT-pt-BR.md
@@ -1,7 +1,7 @@
 # Código de Conduta para Colaboradores
 
 Veja este documento em outro idioma:
-[English](/CODE_OF_CONDUCT.md) / [日本語](.github/CODE_OF_CONDUCT-jp.md) / [简体中文](.github/CODE_OF_CONDUCT-zh-CN.md) / [Español](.github/CODE_OF_CONDUCT-es.md)
+[English](/CODE_OF_CONDUCT.md) / [日本語](CODE_OF_CONDUCT-jp.md) / [简体中文](CODE_OF_CONDUCT-zh-CN.md) / [Español](CODE_OF_CONDUCT-es.md)
 
 ## Nossa promessa
 

--- a/.github/CODE_OF_CONDUCT-zh-CN.md
+++ b/.github/CODE_OF_CONDUCT-zh-CN.md
@@ -1,7 +1,7 @@
 # 参与者行为准则
 
 使用其他语言来阅读本文档:
-[English](CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md)
+[English](/CODE_OF_CONDUCT.md) / [日本語](.github/CODE_OF_CONDUCT-jp.md) / [Español](.github/CODE_OF_CONDUCT-es.md) / [Português](.github/CODE_OF_CONDUCT-pt-BR.md)
 
 ## 我们的誓言
 

--- a/.github/CODE_OF_CONDUCT-zh-CN.md
+++ b/.github/CODE_OF_CONDUCT-zh-CN.md
@@ -1,7 +1,7 @@
 # 参与者行为准则
 
 使用其他语言来阅读本文档:
-[English](/CODE_OF_CONDUCT.md) / [日本語](.github/CODE_OF_CONDUCT-jp.md) / [Español](.github/CODE_OF_CONDUCT-es.md) / [Português](.github/CODE_OF_CONDUCT-pt-BR.md)
+[English](/CODE_OF_CONDUCT.md) / [日本語](CODE_OF_CONDUCT-jp.md) / [Español](CODE_OF_CONDUCT-es.md) / [Português](CODE_OF_CONDUCT-pt-BR.md)
 
 ## 我们的誓言
 

--- a/.github/CONTRIBUTING-es.md
+++ b/.github/CONTRIBUTING-es.md
@@ -1,7 +1,7 @@
 # Contribución
 
 Ver este documento en otro idioma:
-[English](CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[English](/CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
 
 ¿Quieres contribuir al proyecto? ¡Genial!
 

--- a/.github/CONTRIBUTING-es.md
+++ b/.github/CONTRIBUTING-es.md
@@ -1,7 +1,7 @@
 # Contribución
 
 Ver este documento en otro idioma:
-[English](/CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[English](/CONTRIBUTING.md) / [日本語](CONTRIBUTING-jp.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Português](CONTRIBUTING-pt-BR.md) / [한국어](CONTRIBUTING-ko.md)
 
 ¿Quieres contribuir al proyecto? ¡Genial!
 

--- a/.github/CONTRIBUTING-jp.md
+++ b/.github/CONTRIBUTING-jp.md
@@ -1,7 +1,7 @@
 # 貢献する
 
 このドキュメントを別の言語で表示する：
-[English](/CONTRIBUTING.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[English](/CONTRIBUTING.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Español](CONTRIBUTING-es.md) / [Português](CONTRIBUTING-pt-BR.md) / [한국어](CONTRIBUTING-ko.md)
 
 このプロジェクトに貢献したいですか?素晴らしい!
 

--- a/.github/CONTRIBUTING-jp.md
+++ b/.github/CONTRIBUTING-jp.md
@@ -1,7 +1,7 @@
 # 貢献する
 
 このドキュメントを別の言語で表示する：
-[English](CONTRIBUTING.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[English](/CONTRIBUTING.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
 
 このプロジェクトに貢献したいですか?素晴らしい!
 

--- a/.github/CONTRIBUTING-ko.md
+++ b/.github/CONTRIBUTING-ko.md
@@ -1,7 +1,7 @@
 # Contributing(기여하기)
 
 다른 언어로 보기: 
-[English](/CONTRIBUTING.md) / [简体中文](.github/CONTRIBUTING-zh-CN.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [Русский](.github/CONTRIBUTING-ru.md)
+[English](/CONTRIBUTING.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [日本語](CONTRIBUTING-jp.md) / [Español](CONTRIBUTING-es.md) / [Português](CONTRIBUTING-pt-BR.md) / [Русский](CONTRIBUTING-ru.md)
 
 이 프로젝트에 도움을 주고 싶나요? 대단합니다!
 

--- a/.github/CONTRIBUTING-ko.md
+++ b/.github/CONTRIBUTING-ko.md
@@ -1,7 +1,7 @@
 # Contributing(기여하기)
 
 다른 언어로 보기: 
-[English](CONTRIBUTING.md) / [简体中文](.github/CONTRIBUTING-zh-CN.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [Русский](.github/CONTRIBUTING-ru.md)
+[English](/CONTRIBUTING.md) / [简体中文](.github/CONTRIBUTING-zh-CN.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [Русский](.github/CONTRIBUTING-ru.md)
 
 이 프로젝트에 도움을 주고 싶나요? 대단합니다!
 

--- a/.github/CONTRIBUTING-pt-BR.md
+++ b/.github/CONTRIBUTING-pt-BR.md
@@ -1,7 +1,7 @@
 # Contribuindo
 
 Veja este documento em outro idioma:
-[English](/CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Español](.github/CONTRIBUTING-es.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[English](/CONTRIBUTING.md) / [日本語](CONTRIBUTING-jp.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Español](CONTRIBUTING-es.md) / [한국어](CONTRIBUTING-ko.md)
 
 Quer contribuir para este projeto? Legal!
 

--- a/.github/CONTRIBUTING-pt-BR.md
+++ b/.github/CONTRIBUTING-pt-BR.md
@@ -1,7 +1,7 @@
 # Contribuindo
 
 Veja este documento em outro idioma:
-[English](CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Español](.github/CONTRIBUTING-es.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[English](/CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [简体中文](CONTRIBUTING-zh-CN.md) / [Español](.github/CONTRIBUTING-es.md) / [한국어](.github/CONTRIBUTING-ko.md)
 
 Quer contribuir para este projeto? Legal!
 

--- a/.github/CONTRIBUTING-zh-CN.md
+++ b/.github/CONTRIBUTING-zh-CN.md
@@ -1,7 +1,7 @@
 # 贡献
 
 使用其他语言来阅读本文档:
-[English](/CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[English](/CONTRIBUTING.md) / [日本語](CONTRIBUTING-jp.md) / [Español](CONTRIBUTING-es.md) / [Português](CONTRIBUTING-pt-BR.md) / [한국어](CONTRIBUTING-ko.md)
 
 你打算为本项目做贡献？太棒了！
 

--- a/.github/CONTRIBUTING-zh-CN.md
+++ b/.github/CONTRIBUTING-zh-CN.md
@@ -1,7 +1,7 @@
 # 贡献
 
 使用其他语言来阅读本文档:
-[English](CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[English](/CONTRIBUTING.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md) / [한국어](.github/CONTRIBUTING-ko.md)
 
 你打算为本项目做贡献？太棒了！
 

--- a/.github/CONTRUBUTING-ru.md
+++ b/.github/CONTRUBUTING-ru.md
@@ -1,7 +1,7 @@
 # Вклад
 
 Посмотри документы на другом языке:
-[简体中文](.github/CONTRIBUTING-zh-CN.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md)/ [English](../CONTRIBUTING.md) / [한국어](.github/CONTRIBUTING-ko.md)
+[简体中文](CONTRIBUTING-zh-CN.md) / [日本語](CONTRIBUTING-jp.md) / [Español](CONTRIBUTING-es.md) / [Português](CONTRIBUTING-pt-BR.md)/ [English](../CONTRIBUTING.md) / [한국어](CONTRIBUTING-ko.md)
 
 Хочешь внести свой вклад в проект? Отлично!
 

--- a/.github/README-es.md
+++ b/.github/README-es.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href="README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
+  <a href="/README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
 </div>
 
 NES.css es un **NES-style(8bit-like)** CSS Framework.

--- a/.github/README-es.md
+++ b/.github/README-es.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href="/README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
+  <a href="/README.md">English</a> / <a href="README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href="README-pt-BR.md">Português</a>　/ <a href="README-ru.md">Русский</a>
 </div>
 
 NES.css es un **NES-style(8bit-like)** CSS Framework.

--- a/.github/README-fr.md
+++ b/.github/README-fr.md
@@ -126,7 +126,7 @@ Lisez le fichier [`CONTRIBUTING.md`][contributing-document] pour plus de détail
 
 [commitizen]: http://commitizen.github.io/cz-cli/
 [commitizen-badge]: https://img.shields.io/badge/commitizen-friendly-brightgreen.svg
-[contributing-document]: CONTRIBUTING.md
+[contributing-document]: /CONTRIBUTING.md
 [gitter]: https://gitter.im/nostalgic-css/Lobby
 [gitter-badge]: https://img.shields.io/gitter/room/nostalgic-css/Lobby.svg
 [google-fonts-guide]: https://developers.google.com/fonts/docs/getting_started

--- a/.github/README-fr.md
+++ b/.github/README-fr.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href=".github/README-jp.md">日本語</a> / <a href=".github/README-zh-CN.md">简体中文</a> / <a href=".github/README-es.md">Español</a> / <a href=".github/README-pt-BR.md">Português</a> / <a href=".github/README-ru.md">Русский</a> / <a href=".github/README-fr.md">Français</a>
+  <a href="README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a> / <a href="README-ru.md">Русский</a> / <a href="README-fr.md">Français</a>
 </div>
 
 NES.css est un framework CSS **NES-style(8bit-like)**.

--- a/.github/README-jp.md
+++ b/.github/README-jp.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href="README.md">English</a> / <a href="README-zh-CN.md">简体中文</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
+  <a href="/README.md">English</a> / <a href="README-zh-CN.md">简体中文</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
 </div>
 
 NES.cssは **ファミコン風(8bit ライク)** なCSSフレームワークです。

--- a/.github/README-jp.md
+++ b/.github/README-jp.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href="/README.md">English</a> / <a href="README-zh-CN.md">简体中文</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
+  <a href="/README.md">English</a> / <a href="README-zh-CN.md">简体中文</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a>　/ <a href="README-ru.md">Русский</a>
 </div>
 
 NES.cssは **ファミコン風(8bit ライク)** なCSSフレームワークです。

--- a/.github/README-pt-BR.md
+++ b/.github/README-pt-BR.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href="/README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-es.md">Español</a>　/ <a href=".github/README-ru.md">Русский</a>
+  <a href="/README.md">English</a> / <a href="README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href="README-es.md">Español</a>　/ <a href="README-ru.md">Русский</a>
 </div>
 
 NES.css é um Framework CSS, no **estilo NES(8bit)**.

--- a/.github/README-pt-BR.md
+++ b/.github/README-pt-BR.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href="README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-es.md">Español</a>　/ <a href=".github/README-ru.md">Русский</a>
+  <a href="/README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-es.md">Español</a>　/ <a href=".github/README-ru.md">Русский</a>
 </div>
 
 NES.css é um Framework CSS, no **estilo NES(8bit)**.

--- a/.github/README-ru.md
+++ b/.github/README-ru.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href="README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-pt-BR.md">Português</a>
+  <a href="/README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-pt-BR.md">Português</a>
 </div>
 
 NES.css - это CSS фреймворк в стиле **NES(8bit)**

--- a/.github/README-ru.md
+++ b/.github/README-ru.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width: 100%;" width="600" height="315"></a>
 
-  <a href="/README.md">English</a> / <a href=".github/README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href=".github/README-pt-BR.md">Português</a>
+  <a href="/README.md">English</a> / <a href="README-jp.md">日本語</a> / <a href="README-zh-CN.md">简体中文</a> / <a href="README-pt-BR.md">Português</a>
 </div>
 
 NES.css - это CSS фреймворк в стиле **NES(8bit)**

--- a/.github/README-ru.md
+++ b/.github/README-ru.md
@@ -126,7 +126,7 @@ Código y documentación copyright 2018 [B.C.Rikko](https://github.com/BcRikko).
 
 [commitizen]: http://commitizen.github.io/cz-cli/
 [commitizen-badge]: https://img.shields.io/badge/commitizen-friendly-brightgreen.svg
-[contributing-document]: ./CONTRIBUTING-es.md
+[contributing-document]: ./CONTRUBUTING-ru.md
 [gitter]: https://gitter.im/nostalgic-css/Lobby
 [gitter-badge]: https://img.shields.io/gitter/room/nostalgic-css/Lobby.svg
 [google-fonts-guide]: https://developers.google.com/fonts/docs/getting_started

--- a/.github/README-zh-CN.md
+++ b/.github/README-zh-CN.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width:100%;" width="600" height="315"></a>
 
-  <a href="/README.md">English</a> / <a href="README-jp.md">日本語</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
+  <a href="/README.md">English</a> / <a href="README-jp.md">日本語</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a>　/ <a href="README-ru.md">Русский</a>
 </div>
 
 NES.css 是一款 **NES-风格(8位机)** 的CSS 框架.

--- a/.github/README-zh-CN.md
+++ b/.github/README-zh-CN.md
@@ -1,7 +1,7 @@
 <div align="center">
   <a href="https://nostalgic-css.github.io/NES.css/" target="_blank"><img src="https://user-images.githubusercontent.com/5305599/49061716-da649680-f254-11e8-9a89-d95a7407ec6a.png" alt="NES.css: NES-style  CSS framework" style="max-width:100%;" width="600" height="315"></a>
 
-  <a href="README.md">English</a> / <a href="README-jp.md">日本語</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
+  <a href="/README.md">English</a> / <a href="README-jp.md">日本語</a> / <a href="README-es.md">Español</a> / <a href="README-pt-BR.md">Português</a>　/ <a href=".github/README-ru.md">Русский</a>
 </div>
 
 NES.css 是一款 **NES-风格(8位机)** 的CSS 框架.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .vscode
+.idea
 css
 storybook-static
 .DS_Store

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 # Contributor Covenant Code of Conduct
 
 View this document in another language:
-[简体中文](.github/CONTRIBUTING-zh-CN.md) / [日本語](.github/CONTRIBUTING-jp.md) / [Español](.github/CONTRIBUTING-es.md) / [Português](.github/CONTRIBUTING-pt-BR.md)
+[简体中文](.github/CODE_OF_CONDUCT-zh-CN.md) / [日本語](.github/CODE_OF_CONDUCT-jp.md) / [Español](.github/CODE_OF_CONDUCT-es.md) / [Português](.github/CODE_OF_CONDUCT-pt-BR.md)
 
 ## Our Pledge
 


### PR DESCRIPTION
<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**
<!-- What does this PR do, what does it want to achieve? -->
![image](https://user-images.githubusercontent.com/35769340/126042768-a62c06ad-4382-4e1e-8987-7615057716ba.png)

![image](https://user-images.githubusercontent.com/35769340/126042752-3da5a49b-9b45-41ea-84c1-82b8a49d327d.png)
1. In markdown files navigate between different langages will show a 404 page, it casued by relative path of the links.
2. Also fix some paths are not correct.

**Compatibility**
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->
Works on `github.com`, unknown if served by other programs.

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->
No.
