### PR TITLE
fix(button): Remove extra space caused by input type="file"

### DIFF
--- a/scss/elements/buttons.scss
+++ b/scss/elements/buttons.scss
@@ -86,6 +86,6 @@
   input[type="file"] {
     position: absolute;
     pointer-events: none;
-    opacity: 0;
+    display: none;
   }
 }


### PR DESCRIPTION
**Description**
Currently, <input type="file"> elements have opacity: 0 rather than display: none - This is causing them to actually take space, causing an issue on mobile where the <body> expands to the right.

![image](https://user-images.githubusercontent.com/295683/141066441-cc676420-e4bc-4fbe-9f26-bfe37f429456.png)

This change fixes that.

**Compatibility**
No

**Caveats**
None
