### PR TITLE
fix: use border-image-repeat: stretch on chrome

### DIFF
--- a/scss/utilities/rounded-corners-mixin.scss
+++ b/scss/utilities/rounded-corners-mixin.scss
@@ -11,27 +11,12 @@
   border-image-source: url('data:image/svg+xml;utf8,<?xml version="1.0" encoding="UTF-8" ?><svg version="1.1" width="5" height="5" xmlns="http://www.w3.org/2000/svg"><path d="M2 1 h1 v1 h-1 z M1 2 h1 v1 h-1 z M3 2 h1 v1 h-1 z M2 3 h1 v1 h-1 z" fill="rgb(#{red($color)},#{green($color)},#{blue($color)})" /></svg>');
 }
 
-@mixin border-image-repeat() {
-  border-image-repeat: stretch;
-
-  // for chrome
-  @media all and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: 0.001dpcm) {
-    border-image-repeat: space;
-  }
-
-  // for firefox
-  @supports (-moz-appearance: meterbar) {
-    border-image-repeat: stretch;
-  }
-}
-
 @mixin rounded-corners($isDark: false) {
   @extend %rounded-corner-defaults;
 
   border-image-slice: 3;
   border-image-width: 3;
-
-  @include border-image-repeat();
+  border-image-repeat: stretch;
 
   @if $isDark {
     @include border-image($color-white);
@@ -49,8 +34,7 @@
 
   border-image-slice: 2;
   border-image-width: 2;
-
-  @include border-image-repeat();
+  border-image-repeat: stretch;
 
   @if $isDark {
     @include compact-border-image($color-white);


### PR DESCRIPTION
<!-- Please fill your information below the lines starting with `#`. -->
<!-- You can delete these lines enclosed by `<` and `>` before posting, too. -->

**Description**
<!-- What does this PR do, what does it want to achieve? -->
Fixes gaps in the border image on chrome.

| Before         | After     |
|--------------|-----------|
| ![image](https://user-images.githubusercontent.com/32853499/167294061-3f9ac6c4-2a52-4741-bd60-7be3339ce1ac.png) | ![image](https://user-images.githubusercontent.com/32853499/167294092-ca3d3f21-85fb-4d5a-a8db-6d411ed1f46a.png)      |

Basically reverts #319 as it seems that chrome now looks good when using `border-image-repeat: stretch`

**Compatibility**
<!-- Elaborate on how this PR affects the compatibility. Is it breaking, or not? -->

Tested on Chromium 101.0.4951.54

Might (re-)introduce visual bugs for older chrome versions.

**Caveats**
<!-- Is there something specific you'd like to mention before merge? -->
