### PR TITLE
Fix incompatibilities when using package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "nes",
     "framework"
   ],
-  "engines": {
-    "node": ">=10.0.0"
-  },
   "author": "BcRikko (https://github.com/Bcrikko)",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nes.css",
   "description": "NES.css is NES-style CSS Framework.",
+  "version": "2.3.0",
   "scripts": {
     "watch": "npm run build:sass -- --watch",
     "// Build task": "",


### PR DESCRIPTION
**Description**
- [x]  Node version is not really needed in `package.json` (it works perfectly well on 14+)
- [x] Version is now added to `package.json` 